### PR TITLE
Refactor method names in Plans and Subscriptions interfaces for consi…

### DIFF
--- a/src/Contracts/Services/Recurring/PlansInterface.php
+++ b/src/Contracts/Services/Recurring/PlansInterface.php
@@ -18,7 +18,7 @@ interface PlansInterface extends RecurringInterface
      * @param array $optional
      * @return \Faridibin\Paystack\DataTransferObjects\Response
      */
-    public function createPlan(string $name, int $amount, PlanInterval|string $interval, array $optional = []): Response;
+    public function create(string $name, int $amount, PlanInterval|string $interval, array $optional = []): Response;
 
     /**
      * List plans.
@@ -29,7 +29,7 @@ interface PlansInterface extends RecurringInterface
      * @param array $optional
      * @return \Faridibin\Paystack\DataTransferObjects\Response
      */
-    public function listPlans(int $perPage = 50, int $page = 1, array $optional = []): Response;
+    public function list(int $perPage = 50, int $page = 1, array $optional = []): Response;
 
     /**
      * Fetch Plan
@@ -38,7 +38,7 @@ interface PlansInterface extends RecurringInterface
      * @param string $identifier The plan ID or code you want to fetch
      * @return \Faridibin\Paystack\DataTransferObjects\Response
      */
-    public function fetchPlan(string $identifier): Response;
+    public function fetch(string $identifier): Response;
 
     /**
      * Update Plan
@@ -48,5 +48,5 @@ interface PlansInterface extends RecurringInterface
      * @param array $data
      * @return \Faridibin\Paystack\DataTransferObjects\Response
      */
-    public function updatePlan(string $identifier, array $data): Response;
+    public function update(string $identifier, array $data): Response;
 }

--- a/src/Contracts/Services/Recurring/SubscriptionsInterface.php
+++ b/src/Contracts/Services/Recurring/SubscriptionsInterface.php
@@ -16,7 +16,7 @@ interface SubscriptionsInterface extends RecurringInterface
      * @param array $optional
      * @return Response
      */
-    public function createSubscription(string $customer, string $plan, array $optional = []): Response;
+    public function create(string $customer, string $plan, array $optional = []): Response;
 
     /**
      * List subscriptions.
@@ -27,7 +27,7 @@ interface SubscriptionsInterface extends RecurringInterface
      * @param array $optional
      * @return Response
      */
-    public function listSubscriptions(int $perPage = 50, int $page = 1, array $optional = []): Response;
+    public function list(int $perPage = 50, int $page = 1, array $optional = []): Response;
 
     /**
      * Fetch Subscription
@@ -36,7 +36,7 @@ interface SubscriptionsInterface extends RecurringInterface
      * @param string $identifier The subscription ID or code you want to fetch
      * @return Response
      */
-    public function fetchSubscription(string $identifier): Response;
+    public function fetch(string $identifier): Response;
 
     /**
      * Toggle Subscription
@@ -47,7 +47,7 @@ interface SubscriptionsInterface extends RecurringInterface
      * @param bool $active Whether to enable or disable the subscription
      * @return Response
      */
-    public function toggleSubscription(string $code, string $token, bool $active = true): Response;
+    public function toggle(string $code, string $token, bool $active = true): Response;
 
     /**
      * Generate Updated Subscription Link

--- a/src/Services/Recurring/Plans.php
+++ b/src/Services/Recurring/Plans.php
@@ -32,7 +32,7 @@ class Plans implements PlansInterface
      * @param array $optional
      * @return \Faridibin\Paystack\DataTransferObjects\Response
      */
-    public function createPlan(string $name, int $amount, PlanInterval|string $interval, array $optional = []): Response
+    public function create(string $name, int $amount, PlanInterval|string $interval, array $optional = []): Response
     {
         $response = $this->client->send('POST', '/plan', [
             'json' => [
@@ -55,7 +55,7 @@ class Plans implements PlansInterface
      * @param array $optional
      * @return \Faridibin\Paystack\DataTransferObjects\Response
      */
-    public function listPlans(int $perPage = 50, int $page = 1, array $optional = []): Response
+    public function list(int $perPage = 50, int $page = 1, array $optional = []): Response
     {
         $response = $this->client->send('GET', '/plan', [
             'query' => [
@@ -75,7 +75,7 @@ class Plans implements PlansInterface
      * @param string $identifier The plan ID or code you want to fetch
      * @return \Faridibin\Paystack\DataTransferObjects\Response
      */
-    public function fetchPlan(string $identifier): Response
+    public function fetch(string $identifier): Response
     {
         $response = $this->client->send('GET', "/plan/{$identifier}");
 
@@ -90,7 +90,7 @@ class Plans implements PlansInterface
      * @param array $data
      * @return \Faridibin\Paystack\DataTransferObjects\Response
      */
-    public function updatePlan(string $identifier, array $data): Response
+    public function update(string $identifier, array $data): Response
     {
         $response = $this->client->send('PUT', "/plan/{$identifier}", [
             'json' => $data

--- a/src/Services/Recurring/Subscriptions.php
+++ b/src/Services/Recurring/Subscriptions.php
@@ -30,7 +30,7 @@ class Subscriptions implements SubscriptionsInterface
      * @param array $optional
      * @return Response
      */
-    public function createSubscription(string $customer, string $plan, array $optional = []): Response
+    public function create(string $customer, string $plan, array $optional = []): Response
     {
         $response = $this->client->send('POST', '/subscription', [
             'json' => [
@@ -52,7 +52,7 @@ class Subscriptions implements SubscriptionsInterface
      * @param array $optional
      * @return Response
      */
-    public function listSubscriptions(int $perPage = 50, int $page = 1, array $optional = []): Response
+    public function list(int $perPage = 50, int $page = 1, array $optional = []): Response
     {
         $response = $this->client->send('GET', '/subscription', [
             'query' => [
@@ -72,7 +72,7 @@ class Subscriptions implements SubscriptionsInterface
      * @param string $identifier The subscription ID or code you want to fetch
      * @return Response
      */
-    public function fetchSubscription(string $identifier): Response
+    public function fetch(string $identifier): Response
     {
         $response = $this->client->send('GET', "/subscription/{$identifier}");
 
@@ -88,7 +88,7 @@ class Subscriptions implements SubscriptionsInterface
      * @param bool $active Whether to enable or disable the subscription
      * @return Response
      */
-    public function toggleSubscription(string $code, string $token, bool $active = true): Response
+    public function toggle(string $code, string $token, bool $active = true): Response
     {
         $endpoint = sprintf('/subscription/%s', $active ? 'enable' : 'disable');
 


### PR DESCRIPTION
This pull request primarily focuses on renaming several methods in the `PlansInterface` and `SubscriptionsInterface` classes, as well as their implementations in the `Plans` and `Subscriptions` classes, to provide a more consistent and simplified naming convention.

### Interface Method Renaming:

* [`src/Contracts/Services/Recurring/PlansInterface.php`](diffhunk://#diff-d41a91819c529c348ce79a2ad5ea3ad985bff76a395cc7b1efa6d29665660635L21-R21): Renamed methods `createPlan`, `listPlans`, `fetchPlan`, and `updatePlan` to `create`, `list`, `fetch`, and `update` respectively. [[1]](diffhunk://#diff-d41a91819c529c348ce79a2ad5ea3ad985bff76a395cc7b1efa6d29665660635L21-R21) [[2]](diffhunk://#diff-d41a91819c529c348ce79a2ad5ea3ad985bff76a395cc7b1efa6d29665660635L32-R32) [[3]](diffhunk://#diff-d41a91819c529c348ce79a2ad5ea3ad985bff76a395cc7b1efa6d29665660635L41-R41) [[4]](diffhunk://#diff-d41a91819c529c348ce79a2ad5ea3ad985bff76a395cc7b1efa6d29665660635L51-R51)
* [`src/Contracts/Services/Recurring/SubscriptionsInterface.php`](diffhunk://#diff-3d1df37d7656fcf11009e38af3537c5ce4f7bf70bb9b61a55509b3de5e173d7eL19-R19): Renamed methods `createSubscription`, `listSubscriptions`, `fetchSubscription`, and `toggleSubscription` to `create`, `list`, `fetch`, and `toggle` respectively. [[1]](diffhunk://#diff-3d1df37d7656fcf11009e38af3537c5ce4f7bf70bb9b61a55509b3de5e173d7eL19-R19) [[2]](diffhunk://#diff-3d1df37d7656fcf11009e38af3537c5ce4f7bf70bb9b61a55509b3de5e173d7eL30-R30) [[3]](diffhunk://#diff-3d1df37d7656fcf11009e38af3537c5ce4f7bf70bb9b61a55509b3de5e173d7eL39-R39) [[4]](diffhunk://#diff-3d1df37d7656fcf11009e38af3537c5ce4f7bf70bb9b61a55509b3de5e173d7eL50-R50)

### Implementation Method Renaming:

* [`src/Services/Recurring/Plans.php`](diffhunk://#diff-5bcd45a3ea0ad92212ccd38ea5457716a523bf58afa6d3f8b1df6b0451d33246L35-R35): Updated method names to match the interface changes. Methods `createPlan`, `listPlans`, `fetchPlan`, and `updatePlan` are renamed to `create`, `list`, `fetch`, and `update` respectively. [[1]](diffhunk://#diff-5bcd45a3ea0ad92212ccd38ea5457716a523bf58afa6d3f8b1df6b0451d33246L35-R35) [[2]](diffhunk://#diff-5bcd45a3ea0ad92212ccd38ea5457716a523bf58afa6d3f8b1df6b0451d33246L58-R58) [[3]](diffhunk://#diff-5bcd45a3ea0ad92212ccd38ea5457716a523bf58afa6d3f8b1df6b0451d33246L78-R78) [[4]](diffhunk://#diff-5bcd45a3ea0ad92212ccd38ea5457716a523bf58afa6d3f8b1df6b0451d33246L93-R93)
* [`src/Services/Recurring/Subscriptions.php`](diffhunk://#diff-da89d7badd4b9af953cf618c0c952ebc0f00dd87a9b0fad1032c635af2129483L33-R33): Updated method names to match the interface changes. Methods `createSubscription`, `listSubscriptions`, `fetchSubscription`, and `toggleSubscription` are renamed to `create`, `list`, `fetch`, and `toggle` respectively. [[1]](diffhunk://#diff-da89d7badd4b9af953cf618c0c952ebc0f00dd87a9b0fad1032c635af2129483L33-R33) [[2]](diffhunk://#diff-da89d7badd4b9af953cf618c0c952ebc0f00dd87a9b0fad1032c635af2129483L55-R55) [[3]](diffhunk://#diff-da89d7badd4b9af953cf618c0c952ebc0f00dd87a9b0fad1032c635af2129483L75-R75) [[4]](diffhunk://#diff-da89d7badd4b9af953cf618c0c952ebc0f00dd87a9b0fad1032c635af2129483L91-R91)…stency