### PR TITLE
Fix namespace for WebhookEvent enum

### DIFF
--- a/src/Enums/WebhookEvent.php
+++ b/src/Enums/WebhookEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Faridibin\PaystackLaravel\Enums;
+namespace Faridibin\Paystack\Enums;
 
 enum WebhookEvent: string
 {


### PR DESCRIPTION
This pull request includes a namespace change to the `WebhookEvent` enum in the `src/Enums/WebhookEvent.php` file. The change updates the namespace to reflect the correct directory structure.

* [`src/Enums/WebhookEvent.php`](diffhunk://#diff-303c9d9c1b542465f54069d9de0df4e6f0c31c0bc10ca2687ff8d60f18c2e62cL3-R3): Changed the namespace from `Faridibin\PaystackLaravel\Enums` to `Faridibin\Paystack\Enums`.