### PR TITLE
Update PlanDTO to allow nullable readonly properties for send_invoice…

### DIFF
--- a/src/DataTransferObjects/Recurring/PlanDTO.php
+++ b/src/DataTransferObjects/Recurring/PlanDTO.php
@@ -21,14 +21,14 @@ class PlanDTO implements DataTransferObject
      * 
      * @var bool $send_invoices
      */
-    public readonly bool $send_invoices;
+    public readonly bool|null $send_invoices;
 
     /**
      * The send sms status
      * 
      * @var bool $send_sms
      */
-    public readonly bool $send_sms;
+    public readonly bool|null $send_sms;
 
     /**
      * The collection of pages


### PR DESCRIPTION
This pull request includes changes to the `PlanDTO` class in the `src/DataTransferObjects/Recurring/PlanDTO.php` file to allow certain properties to be nullable. The most important changes include modifying the `send_invoices` and `send_sms` properties to accept `null` values.

Changes to `PlanDTO` class:

* [`src/DataTransferObjects/Recurring/PlanDTO.php`](diffhunk://#diff-db62bd70bfd160fc967868c5d8bce2e691053154cdec6392f71983d48636566bL24-R31): Modified the `send_invoices` property to be of type `bool|null` instead of just `bool`.
* [`src/DataTransferObjects/Recurring/PlanDTO.php`](diffhunk://#diff-db62bd70bfd160fc967868c5d8bce2e691053154cdec6392f71983d48636566bL24-R31): Modified the `send_sms` property to be of type `bool|null` instead of just `bool`.…s and send_sms