### PR TITLE
Development

### DIFF
--- a/src/Services/Payments/Refunds.php
+++ b/src/Services/Payments/Refunds.php
@@ -47,6 +47,29 @@ class Refunds implements RefundsInterface
     }
 
     /**
+     * Retry a refund.
+     * Retry a failed refund on your integration
+     *
+     * @param string $id
+     * @param array $optional
+     * @return \Faridibin\Paystack\DataTransferObjects\Response
+     */
+    public function retryRefund(string $id, array $optional = []): Response
+    {
+        $response = $this->client->send('POST', "/retry_with_customer_details/{$id}", [
+            'json' => [
+                ...$optional
+            ]
+        ]);
+
+        return new Response(
+            $response,
+            // CountriesDTO::class,
+            // true
+        );
+    }
+
+    /**
      * List refunds.
      * List refunds available on your integration
      *

--- a/src/Services/Payments/Refunds.php
+++ b/src/Services/Payments/Refunds.php
@@ -50,15 +50,21 @@ class Refunds implements RefundsInterface
      * Retry a refund.
      * Retry a failed refund on your integration
      *
-     * @param string $id
-     * @param array $optional
+     * @param string $identifier
+     * @param Currency|string $currency
+     * @param string $bankId
+     * @param string $accountNumber
      * @return \Faridibin\Paystack\DataTransferObjects\Response
      */
-    public function retryRefund(string $id, array $optional = []): Response
+    public function retryRefund(string $identifier, Currency|string $currency, string $bankId, string $accountNumber): Response
     {
-        $response = $this->client->send('POST', "/retry_with_customer_details/{$id}", [
+        $response = $this->client->send('POST', "/retry_with_customer_details/{$identifier}", [
             'json' => [
-                ...$optional
+                'refund_account_details' => [
+                    'currency' => $currency,
+                    'bank_id' => $bankId,
+                    'account_number' => $accountNumber
+                ],
             ]
         ]);
 


### PR DESCRIPTION
This pull request adds a new method to the refunds service, enabling the ability to retry a failed refund with specific customer bank details. This enhancement provides more flexibility for handling refund failures by allowing retries with updated account information.

Refund functionality improvements:

* Added the `retryRefund` method to the `Refunds` service, allowing a failed refund to be retried using customer bank details (`currency`, `bankId`, and `accountNumber`).