### PR TITLE
Add available_for_direct_debit property to BankDTO constructor

### DIFF
--- a/src/DataTransferObjects/Miscellaneous/BankDTO.php
+++ b/src/DataTransferObjects/Miscellaneous/BankDTO.php
@@ -56,6 +56,7 @@ class BankDTO implements DataTransferObject
      * @param RecipientType|string $type
      * @param bool $pay_with_bank
      * @param bool $supports_transfer
+     * @param bool $available_for_direct_debit
      * @param bool $active
      * @param bool $is_deleted
      * @param DateTime|string $createdAt
@@ -73,6 +74,7 @@ class BankDTO implements DataTransferObject
         RecipientType|string $type,
         public readonly bool $pay_with_bank,
         public readonly bool $supports_transfer,
+        public readonly bool $available_for_direct_debit,
         public readonly bool $active,
         public readonly bool $is_deleted,
         DateTime|string|null $createdAt = null,


### PR DESCRIPTION
This pull request adds support for tracking whether a bank is available for direct debit in the `BankDTO` data transfer object. This is a minor change that introduces a new boolean property and updates the constructor to accept it. 

* Added the `available_for_direct_debit` boolean property to the `BankDTO` class and updated its constructor to include this new parameter. [[1]](diffhunk://#diff-5460628f1ab3f2f3cc6c9e1374e254ae86a6351b6f9d9759fecee1fd13d9ee43R59) [[2]](diffhunk://#diff-5460628f1ab3f2f3cc6c9e1374e254ae86a6351b6f9d9759fecee1fd13d9ee43R77)