### PR TITLE
Refactor BankDTO to use BankType enum and remove RecipientType refere…

### DIFF
--- a/src/DataTransferObjects/Miscellaneous/BankDTO.php
+++ b/src/DataTransferObjects/Miscellaneous/BankDTO.php
@@ -7,7 +7,7 @@ namespace Faridibin\Paystack\DataTransferObjects\Miscellaneous;
 use DateTime;
 use Faridibin\Paystack\Contracts\DataTransferObjects\DataTransferObject;
 use Faridibin\Paystack\Enums\Currency;
-use Faridibin\Paystack\Enums\RecipientType;
+use Faridibin\Paystack\Enums\BankType;
 use Faridibin\Paystack\Traits\MapToArray;
 
 class BankDTO implements DataTransferObject
@@ -22,11 +22,11 @@ class BankDTO implements DataTransferObject
     public readonly Currency $currency;
 
     /**
-     * The type of recipient
+     * The type of bank
      *
-     * @var RecipientType $recipientType
+     * @var BankType $type
      */
-    public readonly RecipientType $type;
+    public readonly BankType $type;
 
     /**
      * The createdAt property of the bank
@@ -53,7 +53,7 @@ class BankDTO implements DataTransferObject
      * @param string|null $gateway
      * @param string $country
      * @param Currency|string $currency
-     * @param RecipientType|string $type
+     * @param BankType|string $type
      * @param bool $pay_with_bank
      * @param bool $supports_transfer
      * @param bool $available_for_direct_debit
@@ -71,7 +71,7 @@ class BankDTO implements DataTransferObject
         public readonly ?string $gateway,
         public readonly string $country,
         Currency|string $currency,
-        RecipientType|string $type,
+        BankType|string $type,
         public readonly bool $pay_with_bank,
         public readonly bool $supports_transfer,
         public readonly bool $available_for_direct_debit,
@@ -81,7 +81,7 @@ class BankDTO implements DataTransferObject
         DateTime|string|null $updatedAt = null,
     ) {
         $this->currency = $currency instanceof Currency ? $currency : Currency::from($currency);
-        $this->type = $type instanceof RecipientType ? $type : RecipientType::from($type);
+        $this->type = $type instanceof BankType ? $type : BankType::from($type);
 
         $this->createdAt = $createdAt instanceof DateTime ? $createdAt : ($createdAt ? new DateTime($createdAt) : null);
         $this->updatedAt = $updatedAt instanceof DateTime ? $updatedAt : ($updatedAt ? new DateTime($updatedAt) : null);

--- a/src/Enums/BankType.php
+++ b/src/Enums/BankType.php
@@ -2,11 +2,12 @@
 
 namespace Faridibin\Paystack\Enums;
 
-enum RecipientType: string
+enum BankType: string
 {
     case GHIPSS = 'ghipss';
     case MOBILE_MONEY = 'mobile_money';
     case KEPSS = 'kepss';
+    case MOBILE_MONEY_BUSINESS = 'mobile_money_business';
     case NUBAN = 'nuban';
     case BASA = 'basa';
 
@@ -21,8 +22,9 @@ enum RecipientType: string
             self::GHIPSS => 'Ghana Interbank Payment and Settlement Systems',
             self::MOBILE_MONEY => 'Mobile Money or MoMo is an account tied to a mobile number',
             self::KEPSS => 'Kenya Electronic Payment and Settlement System',
+            self::MOBILE_MONEY_BUSINESS => 'Mobile Money Business is an account tied to a mobile number for business purposes',
             self::NUBAN => 'Nigerian Uniform Bank Account Number',
-            self::BASA => 'Banking Association South Africa'
+            self::BASA => 'Banking Association South Africa',
         };
     }
 
@@ -37,6 +39,7 @@ enum RecipientType: string
             self::GHIPSS => ['GHS'],
             self::MOBILE_MONEY => ['GHS', 'KES'],
             self::KEPSS => ['KES'],
+            self::MOBILE_MONEY_BUSINESS => ['GHS', 'KES'],
             self::NUBAN => ['NGN'],
             self::BASA => ['ZAR'],
         };


### PR DESCRIPTION
This pull request refactors the handling of bank types in the codebase by introducing a new `BankType` enum and updating the `BankDTO` data transfer object to use it instead of the previously used `RecipientType` enum. This change improves type safety and better reflects the domain model for banks, separating bank types from recipient types. Additionally, the `RecipientType` enum is cleaned up by removing the unused `AUTHORIZATION` case.

**Bank Type Refactoring:**

* Added a new `BankType` enum in `src/Enums/BankType.php`, which defines specific bank types and includes helper methods for descriptions and supported currencies.
* Updated the `BankDTO` class in `src/DataTransferObjects/Miscellaneous/BankDTO.php` to use `BankType` instead of `RecipientType` for the `type` property and constructor parameter, including all related type hints and docblocks. [[1]](diffhunk://#diff-5460628f1ab3f2f3cc6c9e1374e254ae86a6351b6f9d9759fecee1fd13d9ee43L10-R10) [[2]](diffhunk://#diff-5460628f1ab3f2f3cc6c9e1374e254ae86a6351b6f9d9759fecee1fd13d9ee43L25-R29) [[3]](diffhunk://#diff-5460628f1ab3f2f3cc6c9e1374e254ae86a6351b6f9d9759fecee1fd13d9ee43L56-R56) [[4]](diffhunk://#diff-5460628f1ab3f2f3cc6c9e1374e254ae86a6351b6f9d9759fecee1fd13d9ee43L74-R74) [[5]](diffhunk://#diff-5460628f1ab3f2f3cc6c9e1374e254ae86a6351b6f9d9759fecee1fd13d9ee43L84-R84)

**Recipient Type Cleanup:**

* Removed the `AUTHORIZATION` case from the `RecipientType` enum in `src/Enums/RecipientType.php`, along with its references in the description and supported currencies methods. [[1]](diffhunk://#diff-21fd4e60ef7382a6c92883722085fc599f22010b5d55b7dd3776fec3356d9b02L12) [[2]](diffhunk://#diff-21fd4e60ef7382a6c92883722085fc599f22010b5d55b7dd3776fec3356d9b02L26-R25) [[3]](diffhunk://#diff-21fd4e60ef7382a6c92883722085fc599f22010b5d55b7dd3776fec3356d9b02L44)…nces